### PR TITLE
frontend(resumes): integrate resume pages with backend flows

### DIFF
--- a/frontend/src/app/context/AppContext.tsx
+++ b/frontend/src/app/context/AppContext.tsx
@@ -6,9 +6,16 @@ import {
   deleteJobPosting as apiDeleteJobPosting,
   type JobPostingOut,
 } from '../services/jobPostingApi';
+import {
+  listResumes as apiListResumes,
+  uploadResume as apiUploadResume,
+  getResume as apiGetResume,
+  deleteResume as apiDeleteResume,
+  type ResumeResponse,
+} from '../services/resumeApi';
 
 export interface Resume {
-  id: string;
+  id: number;
   fileName: string;
   uploadDate: string;
   fileType: string;
@@ -45,7 +52,9 @@ interface AppContextType {
   logout: () => void;
   signup: (name: string, email: string, password: string) => Promise<void>;
   addResume: (file: File) => Promise<void>;
-  deleteResume: (id: string) => void;
+  deleteResume: (id: number) => Promise<void>;
+  loadResumes: () => Promise<void>;
+  getResumeById: (id: number) => Promise<Resume>;
   addJobPosting: (url: string) => Promise<void>;
   deleteJobPosting: (id: number) => Promise<void>;
   loadJobPostings: () => Promise<void>;
@@ -55,33 +64,32 @@ interface AppContextType {
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
 
-// Mock data
-const mockResumes: Resume[] = [
-  {
-    id: '1',
-    fileName: 'Remington_Steele_Resume.pdf',
-    uploadDate: '2026-03-15',
-    fileType: 'PDF',
-    parsedText: 'Remington Steele\nSoftware Engineer\n\nExperience:\n- 5 years in full-stack development\n- Proficient in Python, JavaScript, React\n- Experience with REST APIs and microservices\n- Docker and CI/CD pipelines\n\nEducation:\nB.S. Computer Science, MIT',
-    preview: 'Remington Steele - Software Engineer with 5 years in full-stack development...',
-  },
-  {
-    id: '2',
-    fileName: 'Software_Engineer_Resume.docx',
-    uploadDate: '2026-03-20',
-    fileType: 'DOCX',
-    parsedText: 'Jane Developer\nSenior Software Engineer\n\nSkills:\n- Backend development with Python, FastAPI\n- Database design with PostgreSQL\n- API development and testing\n- Cloud infrastructure (AWS)\n\nExperience:\n- Built scalable APIs serving 1M+ users\n- Implemented automated testing pipelines',
-    preview: 'Jane Developer - Senior Software Engineer specializing in backend development...',
-  },
-  {
-    id: '3',
-    fileName: 'Backend_API_Resume.pdf',
-    uploadDate: '2026-04-01',
-    fileType: 'PDF',
-    parsedText: 'Alex Martinez\nBackend Engineer\n\nCore Competencies:\n- Python, FastAPI, SQLAlchemy\n- RESTful API design\n- Docker containerization\n- Unit and integration testing\n- Web scraping and data processing\n\nProjects:\n- Developed high-performance API serving 500k requests/day\n- Implemented CI/CD pipelines with GitHub Actions',
-    preview: 'Alex Martinez - Backend Engineer with expertise in Python and FastAPI...',
-  },
-];
+function mapResume(data: ResumeResponse): Resume {
+  const parsedText = data.parsed_text ?? '';
+  const previewText = parsedText.trim();
+
+  let fileType = data.mime_type;
+  if (data.mime_type === 'application/pdf') {
+    fileType = 'PDF';
+  } else if (
+    data.mime_type ===
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ) {
+    fileType = 'DOCX';
+  }
+
+  return {
+    id: data.id,
+    fileName: data.file_name,
+    uploadDate: new Date(data.created_at).toISOString().split('T')[0],
+    fileType,
+    parsedText,
+    preview:
+      previewText.length <= 140
+        ? previewText
+        : `${previewText.slice(0, 140).trim()}...`,
+  };
+}
 
 function mapJobPosting(data: JobPostingOut): JobPosting {
   return {
@@ -96,18 +104,22 @@ function mapJobPosting(data: JobPostingOut): JobPosting {
 }
 
 function readAccessToken(): string {
-  return localStorage.getItem('accessToken') ?? '';
+  const token = localStorage.getItem('accessToken');
+  if (!token) {
+    throw new Error('You must be logged in to perform this action.');
+  }
+  return token;
 }
 
 export function AppProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState<{ name: string; email: string } | null>(null);
-  const [resumes, setResumes] = useState<Resume[]>(mockResumes);
+
+  const [resumes, setResumes] = useState<Resume[]>([]);
   const [jobPostings, setJobPostings] = useState<JobPosting[]>([]);
   const [optimizationResults, setOptimizationResults] = useState<OptimizationResult[]>([]);
 
   const login = async (email: string, password: string) => {
-    // Mock login - in real app this would call an API
     await new Promise(resolve => setTimeout(resolve, 500));
     setIsAuthenticated(true);
     setUser({ name: 'Demo User', email });
@@ -119,28 +131,29 @@ export function AppProvider({ children }: { children: ReactNode }) {
   };
 
   const signup = async (name: string, email: string, password: string) => {
-    // Mock signup
     await new Promise(resolve => setTimeout(resolve, 500));
     setIsAuthenticated(true);
     setUser({ name, email });
   };
 
-  const addResume = async (file: File) => {
-    // Mock file upload
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    const newResume: Resume = {
-      id: Date.now().toString(),
-      fileName: file.name,
-      uploadDate: new Date().toISOString().split('T')[0],
-      fileType: file.name.split('.').pop()?.toUpperCase() || 'PDF',
-      parsedText: 'Mock parsed text from ' + file.name,
-      preview: 'Preview of ' + file.name,
-    };
-    setResumes([...resumes, newResume]);
+  const loadResumes = async () => {
+    const data = await apiListResumes(readAccessToken());
+    setResumes(data.map(mapResume));
   };
 
-  const deleteResume = (id: string) => {
-    setResumes(resumes.filter(r => r.id !== id));
+  const getResumeById = async (id: number): Promise<Resume> => {
+    const data = await apiGetResume(id, readAccessToken());
+    return mapResume(data);
+  };
+
+  const addResume = async (file: File) => {
+    await apiUploadResume(file, readAccessToken());
+    await loadResumes();
+  };
+
+  const deleteResume = async (id: number) => {
+    await apiDeleteResume(id, readAccessToken());
+    setResumes((prev) => prev.filter((resume) => resume.id !== id));
   };
 
   const loadJobPostings = async () => {
@@ -164,11 +177,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
   };
 
   const runOptimization = async (resumeId: string, jobPostingId: string): Promise<OptimizationResult> => {
-    // Mock optimization process
     await new Promise(resolve => setTimeout(resolve, 2000));
 
-    const resume = resumes.find(r => r.id === resumeId);
-    const job = jobPostings.find(j => j.id === jobPostingId);
+    const resume = resumes.find(r => r.id.toString() === resumeId);
+    const job = jobPostings.find(j => j.id === Number(jobPostingId));
 
     const result: OptimizationResult = {
       id: Date.now().toString(),
@@ -202,6 +214,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         signup,
         addResume,
         deleteResume,
+        loadResumes,
+        getResumeById,
         addJobPosting,
         deleteJobPosting,
         loadJobPostings,

--- a/frontend/src/app/pages/ResumeDetailPage.tsx
+++ b/frontend/src/app/pages/ResumeDetailPage.tsx
@@ -19,23 +19,26 @@ export function ResumeDetailPage() {
     setError(null);
 
     if (!id) {
-      setError('Resume id is missing.');
-      setResume(null);
-      setLoading(false);
-      return;
+        setError('Resume id is missing.');
+        setResume(null);
+        setLoading(false);
+        return;
     }
 
-    const foundResume = resumes.find((item) => item.id === id);
+    const numericId = Number(id);
 
-    if (!foundResume) {
-      setResume(null);
-      setLoading(false);
-      return;
+    if (Number.isNaN(numericId)) {
+        setError('Invalid resume id.');
+        setResume(null);
+        setLoading(false);
+        return;
     }
 
-    setResume(foundResume);
+    const foundResume = resumes.find((item) => item.id === numericId);
+
+    setResume(foundResume ?? null);
     setLoading(false);
-  }, [id, resumes]);
+    }, [id, resumes]);
 
   const handleDelete = async () => {
     if (!resume) return;

--- a/frontend/src/app/pages/ResumeDetailPage.tsx
+++ b/frontend/src/app/pages/ResumeDetailPage.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams, useNavigate } from 'react-router';
+import { AuthLayout } from '../components/AuthLayout';
+import { useApp } from '../context/AppContext';
+import { Button } from '../components/Button';
+import { ArrowLeft, Trash2, Sparkles } from 'lucide-react';
+
+export function ResumeDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { resumes, deleteResume } = useApp();
+
+  const [resume, setResume] = useState<(typeof resumes)[number] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    if (!id) {
+      setError('Resume id is missing.');
+      setResume(null);
+      setLoading(false);
+      return;
+    }
+
+    const foundResume = resumes.find((item) => item.id === id);
+
+    if (!foundResume) {
+      setResume(null);
+      setLoading(false);
+      return;
+    }
+
+    setResume(foundResume);
+    setLoading(false);
+  }, [id, resumes]);
+
+  const handleDelete = async () => {
+    if (!resume) return;
+    if (!confirm(`Delete ${resume.fileName}?`)) return;
+
+    setError(null);
+
+    try {
+      await deleteResume(resume.id);
+      navigate('/resumes');
+    } catch (error) {
+      console.error('Delete failed:', error);
+      setError(error instanceof Error ? error.message : 'Failed to delete resume.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <AuthLayout title="Resume Details">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white rounded-[20px] p-12 shadow-md text-center">
+            <p className="text-muted-foreground">Loading resume...</p>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (error && !resume) {
+    return (
+      <AuthLayout title="Resume Details">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white rounded-[20px] p-12 shadow-md text-center">
+            <h2 className="text-2xl mb-4">Unable to Load Resume</h2>
+            <p className="text-muted-foreground mb-6">{error}</p>
+            <Link to="/resumes">
+              <Button variant="primary">Back to Resume Library</Button>
+            </Link>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (!resume) {
+    return (
+      <AuthLayout title="Resume Not Found">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white rounded-[20px] p-12 shadow-md text-center">
+            <h2 className="text-2xl mb-4">Resume Not Found</h2>
+            <p className="text-muted-foreground mb-6">
+              The resume you're looking for doesn't exist.
+            </p>
+            <Link to="/resumes">
+              <Button variant="primary">Back to Resume Library</Button>
+            </Link>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout title="Resume Details">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Link to="/resumes" className="flex items-center gap-2 text-primary hover:underline">
+          <ArrowLeft className="w-4 h-4" />
+          Back to Resume Library
+        </Link>
+
+        <div className="bg-white rounded-[20px] p-8 shadow-md">
+          <div className="flex items-start justify-between mb-6">
+            <div>
+              <h2 className="text-2xl mb-2">{resume.fileName}</h2>
+              <div className="space-y-1 text-muted-foreground">
+                <p>Uploaded: {resume.uploadDate}</p>
+                <p>File Type: {resume.fileType}</p>
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <Link to="/optimize">
+                <Button variant="primary">
+                  <Sparkles className="w-4 h-4 mr-2" />
+                  Optimize This Resume
+                </Button>
+              </Link>
+              <Button variant="destructive" onClick={handleDelete}>
+                <Trash2 className="w-4 h-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 mb-4">{error}</p>
+          )}
+
+          <div className="border-t border-border pt-6">
+            <h3 className="mb-4">Parsed Text</h3>
+            <div className="bg-background rounded-[14px] p-6 font-mono text-sm whitespace-pre-wrap">
+              {resume.parsedText}
+            </div>
+          </div>
+        </div>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/app/pages/ResumesPage.tsx
+++ b/frontend/src/app/pages/ResumesPage.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useRef } from 'react';
+import { Link } from 'react-router';
+import { AuthLayout } from '../components/AuthLayout';
+import { useApp } from '../context/AppContext';
+import { Button } from '../components/Button';
+import { FileText, Upload, Trash2 } from 'lucide-react';
+
+export function ResumesPage() {
+  const { resumes, addResume, deleteResume } = useApp();
+  const [uploading, setUploading] = useState(false);
+  const [loadingList] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileUpload = async (file: File) => {
+    setError(null);
+
+    if (!file) {
+      setError('Please choose a file to upload.');
+      return;
+    }
+
+    const validTypes = [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+
+    if (!validTypes.includes(file.type)) {
+      setError('Please upload a PDF or DOCX file.');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      setError('File size must be 5 MB or smaller.');
+      return;
+    }
+
+    setUploading(true);
+    try {
+      await addResume(file);
+      setError(null);
+    } catch (error) {
+      console.error('Upload failed:', error);
+      setError(error instanceof Error ? error.message : 'Failed to upload resume.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    setError(null);
+
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      handleFileUpload(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(true);
+  };
+
+  const handleDragLeave = () => {
+    setDragActive(false);
+  };
+
+  const handleDelete = async (id: string, fileName: string) => {
+    if (!confirm(`Delete ${fileName}?`)) return;
+
+    setError(null);
+
+    try {
+      await deleteResume(id);
+    } catch (error) {
+      console.error('Delete failed:', error);
+      setError(error instanceof Error ? error.message : 'Failed to delete resume.');
+    }
+  };
+
+  return (
+    <AuthLayout title="Resume Library">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="bg-white rounded-[20px] p-6 shadow-md">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-xl mb-1">Upload Resume</h2>
+              <p className="text-sm text-muted-foreground">
+                Manage your resume library
+              </p>
+            </div>
+            <Button
+              variant="primary"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading}
+            >
+              <Upload className="w-5 h-5 mr-2" />
+              Upload Resume
+            </Button>
+          </div>
+
+          <div
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            className={`border-2 border-dashed rounded-[14px] p-12 text-center transition-all ${
+              dragActive ? 'border-primary bg-primary/5' : 'border-border'
+            }`}
+          >
+            <Upload
+              className={`w-12 h-12 mx-auto mb-4 ${
+                dragActive ? 'text-primary' : 'text-muted-foreground'
+              }`}
+            />
+            <p className="text-lg mb-2">
+              {uploading ? 'Uploading...' : 'Drag and drop your resume here'}
+            </p>
+            <p className="text-sm text-muted-foreground mb-4">
+              or click the button above to browse
+            </p>
+
+            {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
+
+            <div className="space-y-1">
+              <p className="text-sm text-muted-foreground">
+                Accepted file types: PDF, DOCX
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Maximum file size: 5 MB
+              </p>
+            </div>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.docx"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) {
+                handleFileUpload(file);
+              }
+              e.target.value = '';
+            }}
+            className="hidden"
+          />
+        </div>
+
+        {loadingList ? (
+          <div className="bg-white rounded-[20px] p-12 shadow-md text-center">
+            <p className="text-muted-foreground">Loading resumes...</p>
+          </div>
+        ) : resumes.length === 0 ? (
+          <div className="bg-white rounded-[20px] p-12 shadow-md text-center">
+            <FileText className="w-16 h-16 mx-auto mb-4 text-muted-foreground" />
+            <h3 className="text-xl mb-2">No Resumes Yet</h3>
+            <p className="text-muted-foreground mb-6">
+              Upload your first resume to get started with optimization
+            </p>
+            <Button variant="primary" onClick={() => fileInputRef.current?.click()}>
+              Upload Your First Resume
+            </Button>
+          </div>
+        ) : (
+          <div className="grid md:grid-cols-2 gap-6">
+            {resumes.map((resume) => (
+              <div key={resume.id} className="bg-white rounded-[20px] p-6 shadow-md">
+                <div className="flex items-start gap-4">
+                  <div className="w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center flex-shrink-0">
+                    <FileText className="w-6 h-6 text-primary" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="mb-1 truncate">{resume.fileName}</h3>
+                    <p className="text-sm text-muted-foreground mb-1">
+                      Uploaded {resume.uploadDate}
+                    </p>
+                    <p className="text-sm text-muted-foreground mb-1">
+                      Type: {resume.fileType}
+                    </p>
+                    <p className="text-sm text-muted-foreground mt-3 line-clamp-2">
+                      {resume.preview}
+                    </p>
+                    <div className="flex gap-3 mt-4">
+                      <Link to={`/resumes/${resume.id}`}>
+                        <Button variant="primary" className="text-sm px-4 py-2">
+                          View
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="destructive"
+                        className="text-sm px-4 py-2"
+                        onClick={() => handleDelete(resume.id, resume.fileName)}
+                      >
+                        <Trash2 className="w-4 h-4 mr-1" />
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/app/pages/ResumesPage.tsx
+++ b/frontend/src/app/pages/ResumesPage.tsx
@@ -67,7 +67,7 @@ export function ResumesPage() {
     setDragActive(false);
   };
 
-  const handleDelete = async (id: string, fileName: string) => {
+  const handleDelete = async (id: number, fileName: string) => {
     if (!confirm(`Delete ${fileName}?`)) return;
 
     setError(null);

--- a/frontend/src/app/services/resumeApi.ts
+++ b/frontend/src/app/services/resumeApi.ts
@@ -1,0 +1,54 @@
+import { apiRequest } from '../lib/api';
+
+export interface ResumeResponse {
+  id: number;
+  file_name: string;
+  mime_type: string;
+  parsed_text: string | null;
+  created_at: string;
+}
+
+function authHeaders(accessToken: string): HeadersInit {
+  return { Authorization: `Bearer ${accessToken}` };
+}
+
+export function listResumes(accessToken: string): Promise<ResumeResponse[]> {
+  return apiRequest('/api/v1/resumes', {
+    method: 'GET',
+    headers: authHeaders(accessToken),
+  }) as Promise<ResumeResponse[]>;
+}
+
+export function uploadResume(
+  file: File,
+  accessToken: string,
+): Promise<ResumeResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return apiRequest('/api/v1/resumes', {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: formData,
+  }) as Promise<ResumeResponse>;
+}
+
+export function getResume(
+  id: number,
+  accessToken: string,
+): Promise<ResumeResponse> {
+  return apiRequest(`/api/v1/resumes/${id}`, {
+    method: 'GET',
+    headers: authHeaders(accessToken),
+  }) as Promise<ResumeResponse>;
+}
+
+export function deleteResume(
+  id: number,
+  accessToken: string,
+): Promise<void> {
+  return apiRequest(`/api/v1/resumes/${id}`, {
+    method: 'DELETE',
+    headers: authHeaders(accessToken),
+  }) as Promise<void>;
+}


### PR DESCRIPTION
### What changed
added frontend/src/app/services/resumeApi.ts
listResumes(accessToken)
uploadResume(file, accessToken)
getResume(id, accessToken)
deleteResume(id, accessToken)
updated the resume section in frontend/src/app/context/AppContext.tsx
removed mock resume data
changed Resume.id to number
added loadResumes()
added getResumeById(id: number)
mapped backend resume responses into the UI resume shape
made upload/delete use the real backend routes
updated frontend/src/app/pages/ResumesPage.tsx
added loading and inline error state
replaced alert-based validation with inline validation
wired page behavior to the real resume context methods
updated frontend/src/app/pages/ResumeDetailPage.tsx
removed inline resumes.find(...) page logic
added local resume, loading, and error state
fetches resume detail by route id
delete is async and navigates back to /resumes

### Closes
#56, #55, #54