### PR TITLE
frontend(resumes): finalize loading and error states

### DIFF
--- a/frontend/src/app/pages/ResumeDetailPage.tsx
+++ b/frontend/src/app/pages/ResumeDetailPage.tsx
@@ -1,44 +1,53 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router';
 import { AuthLayout } from '../components/AuthLayout';
-import { useApp } from '../context/AppContext';
+import { useApp, type Resume } from '../context/AppContext';
 import { Button } from '../components/Button';
 import { ArrowLeft, Trash2, Sparkles } from 'lucide-react';
 
 export function ResumeDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { resumes, deleteResume } = useApp();
+  const { getResumeById, deleteResume } = useApp();
 
-  const [resume, setResume] = useState<(typeof resumes)[number] | null>(null);
+  const [resume, setResume] = useState<Resume | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
+    const fetchResume = async () => {
+      setLoading(true);
+      setError(null);
 
-    if (!id) {
+      if (!id) {
         setError('Resume id is missing.');
         setResume(null);
         setLoading(false);
         return;
-    }
+      }
 
-    const numericId = Number(id);
+      const numericId = Number(id);
 
-    if (Number.isNaN(numericId)) {
+      if (Number.isNaN(numericId)) {
         setError('Invalid resume id.');
         setResume(null);
         setLoading(false);
         return;
-    }
+      }
 
-    const foundResume = resumes.find((item) => item.id === numericId);
+      try {
+        const foundResume = await getResumeById(numericId);
+        setResume(foundResume);
+      } catch (error) {
+        console.error('Failed to load resume:', error);
+        setResume(null);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-    setResume(foundResume ?? null);
-    setLoading(false);
-    }, [id, resumes]);
+    void fetchResume();
+  }, [id, getResumeById]);
 
   const handleDelete = async () => {
     if (!resume) return;
@@ -125,16 +134,14 @@ export function ResumeDetailPage() {
                   Optimize This Resume
                 </Button>
               </Link>
-              <Button variant="destructive" onClick={handleDelete}>
+              <Button variant="destructive" onClick={() => void handleDelete()}>
                 <Trash2 className="w-4 h-4 mr-2" />
                 Delete
               </Button>
             </div>
           </div>
 
-          {error && (
-            <p className="text-sm text-red-600 mb-4">{error}</p>
-          )}
+          {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
 
           <div className="border-t border-border pt-6">
             <h3 className="mb-4">Parsed Text</h3>

--- a/frontend/src/app/pages/ResumesPage.tsx
+++ b/frontend/src/app/pages/ResumesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router';
 import { AuthLayout } from '../components/AuthLayout';
 import { useApp } from '../context/AppContext';
@@ -6,12 +6,30 @@ import { Button } from '../components/Button';
 import { FileText, Upload, Trash2 } from 'lucide-react';
 
 export function ResumesPage() {
-  const { resumes, addResume, deleteResume } = useApp();
+  const { resumes, addResume, deleteResume, loadResumes } = useApp();
   const [uploading, setUploading] = useState(false);
-  const [loadingList] = useState(false);
+  const [loadingList, setLoadingList] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const fetchResumes = async () => {
+      setLoadingList(true);
+      setError(null);
+
+      try {
+        await loadResumes();
+      } catch (error) {
+        console.error('Failed to load resumes:', error);
+        setError(error instanceof Error ? error.message : 'Failed to load resumes.');
+      } finally {
+        setLoadingList(false);
+      }
+    };
+
+    void fetchResumes();
+  }, [loadResumes]);
 
   const handleFileUpload = async (file: File) => {
     setError(null);
@@ -54,7 +72,7 @@ export function ResumesPage() {
     setError(null);
 
     if (e.dataTransfer.files && e.dataTransfer.files[0]) {
-      handleFileUpload(e.dataTransfer.files[0]);
+      void handleFileUpload(e.dataTransfer.files[0]);
     }
   };
 
@@ -140,7 +158,7 @@ export function ResumesPage() {
             onChange={(e) => {
               const file = e.target.files?.[0];
               if (file) {
-                handleFileUpload(file);
+                void handleFileUpload(file);
               }
               e.target.value = '';
             }}
@@ -191,7 +209,7 @@ export function ResumesPage() {
                       <Button
                         variant="destructive"
                         className="text-sm px-4 py-2"
-                        onClick={() => handleDelete(resume.id, resume.fileName)}
+                        onClick={() => void handleDelete(resume.id, resume.fileName)}
                       >
                         <Trash2 className="w-4 h-4 mr-1" />
                         Delete


### PR DESCRIPTION
Finalize resume page loading/error handling after backend integration.

### Scope:
**ResumesPage.tsx**
  - load resumes on mount with loadResumes()
  - show loading card while loading
  - keep empty-state card
  - show inline upload/delete errors
  
**ResumeDetailPage.tsx**
  - fetch resume by route param with getResumeById(Number(id))
  - show loading state while fetching
  - keep Resume Not Found state for missing resume
  - keep async delete and navigate back to /resumes

### Done when:
- list page loads real resume data on mount
- detail page fetches by id instead of using resumes.find(...)
- loading, empty, and error states are visible and correct

### Closes:
 - #62 